### PR TITLE
DRM not supported on Raspberry Pi 1

### DIFF
--- a/drm.md
+++ b/drm.md
@@ -19,7 +19,7 @@ For platform support, this means that we can support:
  * Windows
  * Mac OS X
  * Linux x64 and x32
- * Linux ARM v6 and v7 (e.g. Raspberry Pi)
+ * Linux ARM v7 and v8 (32bit) (e.g. Raspberry Pi 2 & 3)
 
 ### Android
 


### PR DESCRIPTION
> "There is no widevine support on RPi1 - it would need an armv6 build of widevine which doesn't exist. Besides, the RPi1 doesn't have the CPU performance to decode video in software which is what will happen with widevine decrypted videos, so either way this isn't supported on RPi1."

https://github.com/asciidisco/plugin.video.netflix/issues/98#issuecomment-325163828